### PR TITLE
Set up Cursor Cloud dev environment (Bun + Turbo)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Bun + Turbo monorepo (`andy-portfolio`) with two runnable apps and one shared package:
+
+- `apps/web` — Next.js 16 (App Router, Turbopack) portfolio + blog. Dev on `http://localhost:3000`.
+- `apps/studio` — Sanity Studio CMS. Dev on `http://localhost:3333`.
+- `packages/sanity-config` — shared Sanity schemas/client (no build/lint/test scripts).
+
+### Package manager
+
+The package manager is Bun (pinned to `bun@1.1.38` in root `package.json`). It is installed on the VM and symlinked to `/usr/local/bin/bun`, so it is on `PATH` in non-interactive shells. Dependencies are refreshed automatically by the startup update script (`bun install`).
+
+### Common commands (see root `package.json` / `turbo.json`)
+
+- Run everything in dev: `bun dev` (turbo runs `next dev` + `sanity dev` together).
+- Lint: `bun lint` (only `apps/web` has a lint task; runs `biome check .`).
+- Format: `bun format`.
+- There is no automated test suite in this repo (no `test` scripts).
+
+### Non-obvious caveats
+
+- `bun run build` currently fails at the TypeScript type-check step in `apps/web/src/components/ui/button.tsx` (a pre-existing radix `Slot` vs button-props type mismatch). This is a source/type issue, not an environment problem, and does not affect `bun dev` — the dev server compiles and serves pages normally. The `apps/studio` build succeeds.
+- Env is read from `.env.local`. This environment has no real Sanity/Spotify/Resend credentials; a `.env.local` with placeholder values exists so the dev servers boot and env-validated modules don't crash on import.
+- `apps/web/src/lib/env.ts` validates `SPOTIFY_*` and `RESEND_API_KEY` with Zod and throws at import time if they are missing. Those vars are only imported by the Spotify/email routes and server actions, so missing values only break those specific routes — not the whole site. The placeholders in `.env.local` keep them from throwing.
+- Homepage, projects, and work-history content come from static JSON in `apps/web/src/data`, so the site renders fully without a real Sanity project. The `/blog` route fetches from Sanity but is wrapped in try/catch and falls back to an empty list, so it renders (0 posts) without valid Sanity credentials.
+- The Studio (`sanity dev`) boots with a placeholder `SANITY_STUDIO_PROJECT_ID`, but loading/editing real content requires a real Sanity project ID and login.
+- After editing files, a `.cursor/hooks.json` `afterFileEdit` hook runs `bun x ultracite fix` (Biome auto-format). CI (`.github/workflows/lint.yml`) fails if `bun run fix`/`bun run lint:fix` in `apps/web` produce uncommitted changes, so keep the web app formatted.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Bun + Turbo monorepo and documents durable startup notes for future Cloud agents. No application code was changed.

- Installs Bun `1.1.38` (the pinned package manager) and symlinks it onto `PATH`.
- Update script for future VM boots: `bun install`.
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering commands, env handling, and non-obvious caveats.

## What was verified

| Service | Command | Result |
| --- | --- | --- |
| Web (`apps/web`) | `bun dev` → `next dev` | ✅ Runs on `http://localhost:3000` (HTTP 200 for `/`, `/blog`, `/projects`) |
| Studio (`apps/studio`) | `bun dev` → `sanity dev` | ✅ Runs on `http://localhost:3333` (HTTP 200) |
| Lint | `bun lint` | ✅ Passes (`biome check .`, 84 files) |
| Build | `bun run build` | ⚠️ Studio builds; web fails at TS type-check on a pre-existing type error in `apps/web/src/components/ui/button.tsx` (unrelated to setup) |
| Tests | — | No automated test suite exists in the repo |

## Hello-world demo

Loaded the portfolio homepage, scrolled through the Projects/Work/Skills sections, used the theme toggle to switch dark/light mode, and navigated to `/blog` and `/projects` — all rendered without errors.

[portfolio_web_hello_world_demo.mp4](https://cursor.com/agents/bc-345e5104-1f9c-4079-a358-0898c44f0e2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_web_hello_world_demo.mp4)

## Notes

- No real Sanity/Spotify/Resend credentials are present; a gitignored `.env.local` with placeholders lets the dev servers boot. Homepage/projects/work content is static JSON, so the site renders fully; `/blog` gracefully falls back to an empty list without valid Sanity credentials.
- The `bun run build` type error is pre-existing committed code and was intentionally left unchanged (setup task does not modify app code).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-345e5104-1f9c-4079-a358-0898c44f0e2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-345e5104-1f9c-4079-a358-0898c44f0e2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for the monorepo structure, development commands, linting, formatting, build caveats, fallback behavior, and Studio requirements.
  * Documented the absence of tests and automatic formatting hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->