### PR TITLE
Fix Spotify env parsing and contact send hang

### DIFF
--- a/apps/web/src/actions/index.ts
+++ b/apps/web/src/actions/index.ts
@@ -3,6 +3,8 @@ import { ActionError, defineAction } from "astro:actions";
 import { checkBotId } from "botid/server";
 import { Resend } from "resend";
 
+import { getResendEnv } from "@/lib/env";
+
 const BLOCKED = "We couldn't send your message. Please try again later.";
 
 const escapeHtml = (text: string): string =>
@@ -32,35 +34,32 @@ const escapeHtml = (text: string): string =>
 export const server = {
   sendEmail: defineAction({
     accept: "form",
-    handler: async (input) => {
+    handler: async (input, context) => {
       if (input.projectMilestone) {
         throw new ActionError({ code: "BAD_REQUEST", message: BLOCKED });
       }
 
-      try {
-        const verification = await checkBotId({
-          advancedOptions: { checkLevel: "basic" },
-        });
-        if (verification.isBot) {
-          throw new ActionError({ code: "FORBIDDEN", message: BLOCKED });
+      const hasBotIdHeader = Boolean(context.request.headers.get("x-is-human"));
+
+      if (hasBotIdHeader) {
+        try {
+          const verification = await checkBotId({
+            advancedOptions: { checkLevel: "basic" },
+          });
+          if (verification.isBot) {
+            throw new ActionError({ code: "FORBIDDEN", message: BLOCKED });
+          }
+        } catch (error) {
+          if (error instanceof ActionError) {
+            throw error;
+          }
+          // BotID unavailable — continue with honeypot only.
         }
-      } catch (error) {
-        if (error instanceof ActionError) {
-          throw error;
-        }
-        // BotID may be unavailable locally — continue with honeypot only
       }
 
-      const apiKey = process.env.RESEND_API_KEY;
-      if (!apiKey) {
-        throw new ActionError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: BLOCKED,
-        });
-      }
-
-      const resend = new Resend(apiKey);
-      const to = process.env.CONTACT_EMAIL ?? "josanderson25@gmail.com";
+      const { CONTACT_EMAIL, RESEND_API_KEY } = getResendEnv();
+      const resend = new Resend(RESEND_API_KEY);
+      const to = CONTACT_EMAIL ?? "josanderson25@gmail.com";
       const subject = input.subject || "New Contact Form Submission";
 
       await resend.emails.send({

--- a/apps/web/src/components/botid-init.tsx
+++ b/apps/web/src/components/botid-init.tsx
@@ -1,23 +1,14 @@
 "use client";
 
-import { initBotId } from "botid/client/core";
-import { useEffect } from "react";
-
-// Astro Actions post to `/_actions/<name>`, not the page URL.
-// Next.js Server Actions posted to `/contact` — that protect path must not be reused here.
-const BotIdInit = () => {
-  useEffect(() => {
-    initBotId({
-      protect: [
-        {
-          advancedOptions: { checkLevel: "basic" },
-          method: "POST",
-          path: "/_actions/sendEmail",
-        },
-      ],
-    });
-  }, []);
-  return null;
-};
+/**
+ * BotID client challenge was intercepting `POST /_actions/sendEmail` and could
+ * stall indefinitely when the challenge script never resolved, leaving the
+ * contact form stuck on “Sending…”.
+ *
+ * Server-side `checkBotId` still runs when the browser sends `x-is-human`
+ * (e.g. after re-enabling client protect). Until then, honeypot + Resend handle
+ * contact spam.
+ */
+const BotIdInit = () => null;
 
 export default BotIdInit;

--- a/apps/web/src/components/contact-form.tsx
+++ b/apps/web/src/components/contact-form.tsx
@@ -61,15 +61,24 @@ const ContactForm = () => {
 
     const formData = new FormData(e.currentTarget);
     startTransition(async () => {
-      const result = await actions.sendEmail(formData);
-      if (result.error) {
-        toast.error(result.error.message || "Failed to send message.");
-        return;
+      try {
+        const result = await actions.sendEmail(formData);
+
+        if (result.error) {
+          toast.error(result.error.message || "Failed to send message.");
+          return;
+        }
+        toast.success(result.data?.message || "Message sent!");
+        setErrors({});
+        setForm(initialForm);
+        formRef.current?.reset();
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to send message. Please try again."
+        );
       }
-      toast.success(result.data?.message || "Message sent!");
-      setErrors({});
-      setForm(initialForm);
-      formRef.current?.reset();
     });
   };
 

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -1,24 +1,52 @@
 import { z } from "zod";
 
-const envSchema = z.object({
-  CONTACT_EMAIL: z.email().optional(),
-  RESEND_API_KEY: z.string().min(1),
+const optionalEmail = z.preprocess((value) => {
+  const parsed = z.string().optional().safeParse(value);
+  if (!parsed.success || !parsed.data) {
+    return;
+  }
+  const trimmed = parsed.data.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}, z.email().optional());
+
+const readEnv = (key: string): string | undefined => {
+  const raw = process.env[key] ?? import.meta.env[key];
+  const parsed = z.string().optional().safeParse(raw);
+  if (!parsed.success || !parsed.data) {
+    return undefined;
+  }
+  const trimmed = parsed.data.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const spotifyEnvSchema = z.object({
   SPOTIFY_CLIENT_ID: z.string().min(1),
   SPOTIFY_CLIENT_SECRET: z.string().min(1),
   SPOTIFY_REFRESH_TOKEN: z.string().min(1),
 });
 
-export const getServerEnv = () =>
-  envSchema.parse({
-    CONTACT_EMAIL: process.env.CONTACT_EMAIL ?? import.meta.env.CONTACT_EMAIL,
-    RESEND_API_KEY:
-      process.env.RESEND_API_KEY ?? import.meta.env.RESEND_API_KEY,
-    SPOTIFY_CLIENT_ID:
-      process.env.SPOTIFY_CLIENT_ID ?? import.meta.env.SPOTIFY_CLIENT_ID,
-    SPOTIFY_CLIENT_SECRET:
-      process.env.SPOTIFY_CLIENT_SECRET ??
-      import.meta.env.SPOTIFY_CLIENT_SECRET,
-    SPOTIFY_REFRESH_TOKEN:
-      process.env.SPOTIFY_REFRESH_TOKEN ??
-      import.meta.env.SPOTIFY_REFRESH_TOKEN,
+const resendEnvSchema = z.object({
+  CONTACT_EMAIL: optionalEmail,
+  RESEND_API_KEY: z.string().min(1),
+});
+
+/** Spotify API routes — does not require Resend or contact env. */
+export const getSpotifyEnv = () =>
+  spotifyEnvSchema.parse({
+    SPOTIFY_CLIENT_ID: readEnv("SPOTIFY_CLIENT_ID"),
+    SPOTIFY_CLIENT_SECRET: readEnv("SPOTIFY_CLIENT_SECRET"),
+    SPOTIFY_REFRESH_TOKEN: readEnv("SPOTIFY_REFRESH_TOKEN"),
   });
+
+/** Contact action + email webhook. */
+export const getResendEnv = () =>
+  resendEnvSchema.parse({
+    CONTACT_EMAIL: readEnv("CONTACT_EMAIL"),
+    RESEND_API_KEY: readEnv("RESEND_API_KEY"),
+  });
+
+/** @deprecated Prefer getSpotifyEnv or getResendEnv for route-specific parsing. */
+export const getServerEnv = () => ({
+  ...getSpotifyEnv(),
+  ...getResendEnv(),
+});

--- a/apps/web/src/pages/api/spotify/authorize.ts
+++ b/apps/web/src/pages/api/spotify/authorize.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 
-import { getServerEnv } from "@/lib/env";
+import { getSpotifyEnv } from "@/lib/env";
 import { buildOAuthStateCookie, createOAuthState } from "@/lib/spotify-oauth";
 
 export const prerender = false;
@@ -17,7 +17,7 @@ const SPOTIFY_SCOPES = [
  * Prefer the www origin used by this site (https://www.andersonjoseph.com).
  */
 export const GET: APIRoute = ({ url }) => {
-  const env = getServerEnv();
+  const env = getSpotifyEnv();
   const secure = url.protocol === "https:";
   const state = createOAuthState();
   const redirectUri = new URL("/api/spotify/callback", url.origin).toString();

--- a/apps/web/src/pages/api/spotify/callback.ts
+++ b/apps/web/src/pages/api/spotify/callback.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 import { z } from "zod";
 
-import { getServerEnv } from "@/lib/env";
+import { getSpotifyEnv } from "@/lib/env";
 import {
   clearOAuthStateCookie,
   escapeHtml,
@@ -66,7 +66,7 @@ export const GET: APIRoute = async ({ request, url }) => {
   }
 
   try {
-    const env = getServerEnv();
+    const env = getSpotifyEnv();
     const redirectUri = new URL("/api/spotify/callback", url.origin).toString();
     const basic = Buffer.from(
       `${env.SPOTIFY_CLIENT_ID}:${env.SPOTIFY_CLIENT_SECRET}`

--- a/apps/web/src/pages/api/spotify/now-playing.ts
+++ b/apps/web/src/pages/api/spotify/now-playing.ts
@@ -1,20 +1,16 @@
 import type { APIRoute } from "astro";
 import { z } from "zod";
 
-import { getServerEnv } from "@/lib/env";
+import { getSpotifyEnv } from "@/lib/env";
 
 export const prerender = false;
 
 const HTTP_STATUS_NO_CONTENT = 204;
 const IDLE_PAYLOAD = { isPlaying: false } as const;
 
-const httpsUrlSchema = z.url().refine((value) => value.startsWith("https://"), {
-  message: "Expected an https URL",
-});
-
 const spotifyImageSchema = z.object({
   height: z.number().optional(),
-  url: httpsUrlSchema,
+  url: z.string().min(1),
   width: z.number().optional(),
 });
 
@@ -35,7 +31,7 @@ const spotifyTrackSchema = z.object({
     .optional(),
   external_urls: z
     .object({
-      spotify: httpsUrlSchema.optional(),
+      spotify: z.string().optional(),
     })
     .optional(),
   name: z.string().min(1),
@@ -79,7 +75,7 @@ const recentlyPlayedSchema = z.object({
 
 const getAccessToken = async (): Promise<string | null> => {
   try {
-    const env = getServerEnv();
+    const env = getSpotifyEnv();
     const basic = Buffer.from(
       `${env.SPOTIFY_CLIENT_ID}:${env.SPOTIFY_CLIENT_SECRET}`
     ).toString("base64");
@@ -168,7 +164,9 @@ export const GET: APIRoute = async () => {
   try {
     const accessToken = await getAccessToken();
     if (!accessToken) {
-      return Response.json(IDLE_PAYLOAD);
+      return Response.json(IDLE_PAYLOAD, {
+        headers: { "Cache-Control": "no-store" },
+      });
     }
 
     const currentRes = await fetch(
@@ -179,24 +177,33 @@ export const GET: APIRoute = async () => {
     );
 
     if (currentRes.status === HTTP_STATUS_NO_CONTENT || !currentRes.ok) {
-      return Response.json(await fetchRecentlyPlayed(accessToken));
+      return Response.json(await fetchRecentlyPlayed(accessToken), {
+        headers: { "Cache-Control": "no-store" },
+      });
     }
 
     const parsed = currentlyPlayingSchema.safeParse(await currentRes.json());
     if (!parsed.success) {
-      return Response.json(await fetchRecentlyPlayed(accessToken));
+      return Response.json(await fetchRecentlyPlayed(accessToken), {
+        headers: { "Cache-Control": "no-store" },
+      });
     }
 
     const itemParsed = spotifyTrackSchema.safeParse(parsed.data.item);
     if (!itemParsed.success) {
-      return Response.json(await fetchRecentlyPlayed(accessToken));
+      return Response.json(await fetchRecentlyPlayed(accessToken), {
+        headers: { "Cache-Control": "no-store" },
+      });
     }
 
     return Response.json(
-      toNowPlayingPayload(itemParsed.data, Boolean(parsed.data.is_playing))
+      toNowPlayingPayload(itemParsed.data, Boolean(parsed.data.is_playing)),
+      { headers: { "Cache-Control": "no-store" } }
     );
   } catch {
     // Never 500 the widget — idle payload hides cleanly on the client.
-    return Response.json(IDLE_PAYLOAD);
+    return Response.json(IDLE_PAYLOAD, {
+      headers: { "Cache-Control": "no-store" },
+    });
   }
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two production issues:

1. **Spotify widget hidden despite 200** — `getServerEnv()` required Resend/contact vars, so Spotify routes could fail env validation before any Spotify API call (matches Vercel "No outgoing requests"). Split into `getSpotifyEnv()` / `getResendEnv()` with trimmed values and relaxed track parsing.

2. **Contact form stuck on "Sending…"** — BotID client fetch wrapper awaited a challenge that could hang forever. Disabled client interception; server verifies BotID only when `x-is-human` is present; added try/catch for action errors.

## Test plan

- [x] Local `POST /_actions/sendEmail` returns success
- [ ] Production contact form completes with toast
- [ ] Production `/api/spotify/now-playing` returns track `name` when Vercel Spotify creds match
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-345e5104-1f9c-4079-a358-0898c44f0e2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-345e5104-1f9c-4079-a358-0898c44f0e2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved contact form submission handling with clearer error messages when sending fails.
  - Expanded support for displaying valid Spotify artwork and external links.

- **Bug Fixes**
  - Spotify “Now Playing” data is no longer unnecessarily cached, helping displayed track information stay current.
  - Contact form spam protection continues to work with fallback safeguards when enhanced verification is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->